### PR TITLE
fix: letters fly back smoothly to original position

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -100,14 +100,10 @@ body {
   animation-delay: var(--delay);
 }
 
-.letter--settle {
-  animation: none;
-  /* transform is set via inline style from JS */
-}
-
+.letter--settle,
 .letter--return {
-  transform: translate(0, 0) rotate(0deg);
   animation: none;
+  /* transform handled by inline style for smooth transition */
 }
 
 @keyframes fly {


### PR DESCRIPTION
- Use useLayoutEffect to capture transforms before paint
- Apply inline transforms for both settle AND return phases
- Transition animates from frozen position to origin
- No more snapping