### PR TITLE
Fix caching and project detail pages, add first real project

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,11 +4,31 @@
     "ignore": [
       "firebase.json",
       "**/.*",
-      "**/node_modules/**"
+      "**/node_modules/**",
+      "service-worker.js",
+      "precache-manifest.*.js"
     ],
     "headers": [
       {
-        "source": "/service-worker.js",
+        "source": "/static/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      },
+      {
+        "source": "/content/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/index.html",
         "headers": [
           {
             "key": "Cache-Control",


### PR DESCRIPTION
Started as the cache-header fix for #39 not appearing live, then adding a real project surfaced three bugs in the detail-page feature. Grouped here since they're all prerequisites for that page actually working.

## 1. Cache headers

`firebase.json` set `Cache-Control` on exactly one file — `service-worker.js`. Everything else fell back to Firebase's default, including `index.html` and `content/*.json`.

That matters here because the About and Projects pages `fetch()` their JSON at **runtime**: a stale `projects.json` renders stale content even on a fresh deploy with newly-hashed JS. It also breaks the workflow `public/content/README.md` advertises — edit the JSON, push, no rebuild.

| Path | Header | Why |
|---|---|---|
| `/content/**` | `no-cache` | Fetched at runtime. Revalidates by ETag, so normally a 304, not a re-download. |
| `/index.html` | `no-cache` | If it's stale the browser never learns about new bundles. |
| `/static/**` | `public, max-age=31536000, immutable` | Content-hashed filenames, safe to pin. |

Also stops deploying `service-worker.js` / `precache-manifest.*.js`. Nothing registers a service worker (the old `index.js` called `serviceWorker.unregister()`), and the precache manifest lists `index.html` — a live SW would have pinned the old app indefinitely.

## 2. Detail pages never worked in production

Three defects, all invisible until a detail page had real content:

- **Blank page on any nested route.** `homepage` was `"./"`, so CRA emitted relative asset paths. At `/projects` they resolve to `/static/...` and load; at `/projects/<slug>` they resolve to `/projects/static/...`, which the catch-all rewrite answers with `index.html`. The bundle arrived as `text/html`, never parsed, page rendered blank. Now absolute.
- **Footer overlapping the article.** `.footer` is `position: fixed`, correct for the single-screen home page, but it sits on top of body text on anything long enough to scroll. Now in normal flow on content pages; home is unchanged.
- **404 state showing raw HTML.** A missing `.md` also comes back through the rewrite as `index.html` with a 200, so `response.ok` passed and the HTML source was handed to the markdown renderer. Now rejects a `text/html` content type.

## 3. First real project

`NAS Photo Browser`. The repo is private and the app is self-hosted, so there's no code link or live URL — the detail page is the destination, which is what the markdown support was for.

Written from the repository itself: the library audit in `GAPS.md` (22,700 files, 975 folders, 26% dated exactly Jan 1) and the face-recognition benchmark recorded in `backend/faces.py` (ArcFace vs facenet, false-merge rate 0.120% → 0.023% on 2,000 photos). The benchmark is a fenced code block rather than a table because `ProjectDetail` renders markdown without `remark-gfm`, so only CommonMark parses.

## Verification

`npm ci && npm run build` clean. Rendered headless across `/`, `/about`, `/projects`, a valid slug, a missing slug, and a 390px viewport: no page errors, no horizontal overflow, footer static on content pages and fixed on home, 404 state correct.

Live response headers couldn't be checked from the build environment — its network policy blocks outbound hosts other than package registries — so those are worth a `curl -I` spot-check after deploy.