### PR TITLE
Fix cache headers on rewritten routes, add Frame Art

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,29 +10,20 @@
     ],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
         "source": "/static/**",
         "headers": [
           {
             "key": "Cache-Control",
             "value": "public, max-age=31536000, immutable"
-          }
-        ]
-      },
-      {
-        "source": "/content/**",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache"
-          }
-        ]
-      },
-      {
-        "source": "/index.html",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache"
           }
         ]
       }

--- a/public/content/projects.json
+++ b/public/content/projects.json
@@ -4,6 +4,11 @@
       "title": "NAS Photo Browser",
       "description": "A self-hosted photo library for 22,700 files on a NAS, built to be used from a phone. Faces are clustered with ArcFace so people can be named once and found everywhere, and CLIP embeddings make the library searchable in plain language.",
       "slug": "nas-photo-browser"
+    },
+    {
+      "title": "Frame Art",
+      "description": "Public-domain museum art on a Samsung Frame TV, matched to the room it hangs in. Claude reads a photo of the wall once; a local weighted scorer handles every artwork after that, so browsing stays instant and free.",
+      "slug": "frame-art"
     }
   ]
 }

--- a/public/content/projects.json
+++ b/public/content/projects.json
@@ -2,12 +2,12 @@
   "projects": [
     {
       "title": "NAS Photo Browser",
-      "description": "A self-hosted photo library for 22,700 files on a NAS, built to be used from a phone. Faces are clustered with ArcFace so people can be named once and found everywhere, and CLIP embeddings make the library searchable in plain language.",
+      "description": "A self-hosted photo library for 22,700 files on a NAS. Faces are clustered with ArcFace to group people without labelling, and CLIP embeddings allow searching by description.",
       "slug": "nas-photo-browser"
     },
     {
       "title": "Frame Art",
-      "description": "Public-domain museum art on a Samsung Frame TV, matched to the room it hangs in. Claude reads a photo of the wall once; a local weighted scorer handles every artwork after that, so browsing stays instant and free.",
+      "description": "Public-domain museum art on a Samsung Frame TV, selected to match the room. Claude analyses a photo of the wall; a local weighted scorer ranks individual artworks.",
       "slug": "frame-art"
     }
   ]

--- a/public/content/projects/frame-art.md
+++ b/public/content/projects/frame-art.md
@@ -1,47 +1,42 @@
 # Frame Art
 
-Museum art on a Samsung Frame TV, curated for the room it hangs in.
+Museum art on a Samsung Frame TV, selected to match the room.
 
 ## The problem
 
-The Frame is a television that pretends to be a painting when you are not
-watching it. Samsung sells the art for it through a subscription, about six
-dollars a month, on top of the cost of the set.
+The Samsung Frame displays artwork when the TV is idle. Samsung sells that
+artwork through a subscription of about six dollars a month.
 
-Meanwhile the Art Institute of Chicago, the Met, the Rijksmuseum, and the
-Smithsonian all publish their public-domain collections through open APIs, at
-full resolution, for free. The art was never the hard part. Choosing which
-pieces belong on a particular wall is.
+The Art Institute of Chicago, the Met, the Rijksmuseum, and the Smithsonian
+publish their public-domain collections through open APIs, at full resolution,
+for free. The harder problem is deciding which pieces suit a particular wall.
 
 ## What it does
 
-A React Native app talks to a small Python service running on the same network.
-The service searches the four museum collections, scores results against what
-you have liked before and what your room looks like, and pushes the ones you
-pick to the TV over its WebSocket art API, matte and all.
+A React Native app talks to a Python service on the same network. The service
+searches the four museum collections, scores results against previous likes and
+a profile of the room, and pushes selected pieces to the TV over its WebSocket
+art API, including matte settings.
 
-Nothing runs in the cloud. There is no account and no server of mine in the
-middle.
+Everything runs on the LAN. There is no account and no hosted server.
 
 ## Matching art to a room
 
-You photograph the wall. Claude reads the photo and returns a structured
-assessment: wall color as hex, lighting, interior style, dominant palette, mood,
-and which art styles and palettes would complement it. That becomes a room
-profile the rest of the system scores against.
+You photograph the wall. Claude returns a structured assessment of the photo:
+wall color as hex, lighting, interior style, dominant palette, mood, and which
+art styles and palettes would complement it. That becomes a room profile used
+for scoring.
 
-That call is slow and costs money, so it happens once per room rather than once
-per artwork.
+The call is slow and metered, so it runs once per room rather than once per
+artwork.
 
-## Why most of it never calls Claude
+## Local scoring
 
-The browsing feed shows a match percentage on every card. Doing that through an
-API would mean a request per artwork, which is both too slow to scroll and
-absurd to pay for.
+The browsing feed shows a match percentage on every card, which through the API
+would mean one request per artwork.
 
-So scoring is split in two. Claude handles the infrequent, genuinely hard
-judgment: reading a room, assembling a themed collection. Everything per-item
-runs locally as a weighted sum:
+Scoring is therefore split. Claude handles room analysis and assembling themed
+collections. The per-artwork score is a local weighted sum:
 
 ```
     artist match     0.25
@@ -52,44 +47,37 @@ runs locally as a weighted sum:
     room match       0.10
 ```
 
-Each component degrades to a neutral 0.5 rather than zero when there is nothing
-to go on, so a new user with no history gets a middling score instead of a
-uniformly bad one. Keyword matching is implicit: the more often a tag shows up
-in art you liked, the more it counts, normalized against how much history exists
-rather than against a fixed threshold.
-
-The result is that swiping is instant and free, and the expensive model is
-reserved for the two places where it is actually better than arithmetic.
+Each component falls back to 0.5 rather than 0 when there is no data, so a new
+user with no history gets a mid-range score rather than a low one. Keyword
+matching is implicit: tags that appear often in liked art count for more,
+normalized against the amount of history rather than a fixed threshold.
 
 ## Color
 
 Palette extraction runs KMeans over the pixels of a 150x150 thumbnail and
-returns the five cluster centers ordered by cluster size, so the dominant color
-comes first.
+returns five cluster centers ordered by cluster size.
 
-Harmony between two palettes is scored in HSV using color theory rather than
-distance. Complementary hues, roughly 180 degrees apart, and analogous hues
-within 30 degrees both score well. Hues around 60 and 120 degrees apart clash.
-Colors with very low saturation are treated as compatible with everything, which
-is the correct answer for the grays and creams most walls actually are. Every
-cross-pair is scored and weighted by how dominant each color is in its palette.
+Harmony between two palettes is scored in HSV. Complementary hues near 180
+degrees apart and analogous hues within 30 degrees score highest; hues near 60
+and 120 degrees apart score lowest. Colors with very low saturation are treated
+as compatible with anything, which covers most wall colors. Every cross-pair is
+scored and weighted by each color's dominance in its palette.
 
-Matte color is a related but different problem. The right matte is analogous to
-the wall in hue but separated from it in lightness, because a matte that matches
-the wall too closely stops reading as a frame at all.
+Matte selection uses a different rule: a hue analogous to the wall, separated in
+lightness so the matte stays visible against it.
 
 ## Talking to the TV
 
-Connection, upload, matte configuration, selecting the active piece, deleting,
-and slideshow scheduling all go over the Frame's WebSocket art API. The
-integration is optional and lazily imported, so the backend and its 40 tests run
-fine on a machine with no television attached.
+Connection, upload, matte configuration, selecting the active piece, deletion,
+and slideshow scheduling go over the Frame's WebSocket art API. The integration
+is optional and lazily imported, so the backend and its 40 tests run without a
+TV present.
 
 A scheduler rotates art by season and time of day, producing search keywords and
-matte recommendations that feed back into the same scoring path.
+matte recommendations that feed back into scoring.
 
 ## Stack
 
 Python with FastAPI and Pydantic, scikit-learn and Pillow for the color work,
 the Anthropic SDK for curation. React Native on Expo with react-query and
-zustand. Runs on a machine on the LAN.
+zustand.

--- a/public/content/projects/frame-art.md
+++ b/public/content/projects/frame-art.md
@@ -1,0 +1,95 @@
+# Frame Art
+
+Museum art on a Samsung Frame TV, curated for the room it hangs in.
+
+## The problem
+
+The Frame is a television that pretends to be a painting when you are not
+watching it. Samsung sells the art for it through a subscription, about six
+dollars a month, on top of the cost of the set.
+
+Meanwhile the Art Institute of Chicago, the Met, the Rijksmuseum, and the
+Smithsonian all publish their public-domain collections through open APIs, at
+full resolution, for free. The art was never the hard part. Choosing which
+pieces belong on a particular wall is.
+
+## What it does
+
+A React Native app talks to a small Python service running on the same network.
+The service searches the four museum collections, scores results against what
+you have liked before and what your room looks like, and pushes the ones you
+pick to the TV over its WebSocket art API, matte and all.
+
+Nothing runs in the cloud. There is no account and no server of mine in the
+middle.
+
+## Matching art to a room
+
+You photograph the wall. Claude reads the photo and returns a structured
+assessment: wall color as hex, lighting, interior style, dominant palette, mood,
+and which art styles and palettes would complement it. That becomes a room
+profile the rest of the system scores against.
+
+That call is slow and costs money, so it happens once per room rather than once
+per artwork.
+
+## Why most of it never calls Claude
+
+The browsing feed shows a match percentage on every card. Doing that through an
+API would mean a request per artwork, which is both too slow to scroll and
+absurd to pay for.
+
+So scoring is split in two. Claude handles the infrequent, genuinely hard
+judgment: reading a room, assembling a themed collection. Everything per-item
+runs locally as a weighted sum:
+
+```
+    artist match     0.25
+    style match      0.20
+    color harmony    0.20
+    keyword match    0.15
+    not disliked     0.10
+    room match       0.10
+```
+
+Each component degrades to a neutral 0.5 rather than zero when there is nothing
+to go on, so a new user with no history gets a middling score instead of a
+uniformly bad one. Keyword matching is implicit: the more often a tag shows up
+in art you liked, the more it counts, normalized against how much history exists
+rather than against a fixed threshold.
+
+The result is that swiping is instant and free, and the expensive model is
+reserved for the two places where it is actually better than arithmetic.
+
+## Color
+
+Palette extraction runs KMeans over the pixels of a 150x150 thumbnail and
+returns the five cluster centers ordered by cluster size, so the dominant color
+comes first.
+
+Harmony between two palettes is scored in HSV using color theory rather than
+distance. Complementary hues, roughly 180 degrees apart, and analogous hues
+within 30 degrees both score well. Hues around 60 and 120 degrees apart clash.
+Colors with very low saturation are treated as compatible with everything, which
+is the correct answer for the grays and creams most walls actually are. Every
+cross-pair is scored and weighted by how dominant each color is in its palette.
+
+Matte color is a related but different problem. The right matte is analogous to
+the wall in hue but separated from it in lightness, because a matte that matches
+the wall too closely stops reading as a frame at all.
+
+## Talking to the TV
+
+Connection, upload, matte configuration, selecting the active piece, deleting,
+and slideshow scheduling all go over the Frame's WebSocket art API. The
+integration is optional and lazily imported, so the backend and its 40 tests run
+fine on a machine with no television attached.
+
+A scheduler rotates art by season and time of day, producing search keywords and
+matte recommendations that feed back into the same scoring path.
+
+## Stack
+
+Python with FastAPI and Pydantic, scikit-learn and Pillow for the color work,
+the Anthropic SDK for curation. React Native on Expo with react-query and
+zustand. Runs on a machine on the LAN.

--- a/public/content/projects/nas-photo-browser.md
+++ b/public/content/projects/nas-photo-browser.md
@@ -1,51 +1,45 @@
 # NAS Photo Browser
 
-A self-hosted photo library for a NAS, built to be used from a phone.
+A self-hosted photo library for a NAS, used from a phone.
 
 ## The problem
 
 Twenty years of family photos had accumulated on a NAS: 22,700 files across 975
-folders, about 132 GB, dated 1990 through 2026. All of it was reachable over SMB
-and none of it was browsable. Finding one picture meant opening folders by name
-on a laptop and guessing.
+folders, about 132 GB, dated 1990 through 2026. The files were reachable over
+SMB but there was no way to browse them. Finding a photo meant opening folders
+by name on a laptop.
 
-Cloud services solve this by taking custody of the files. I wanted the library to
-stay where it was and get a good interface on top of it.
+Cloud services solve this by taking custody of the files. I wanted to leave the
+library where it was and put an interface on top of it.
 
 ## What it does
 
 The server mounts the share read-only, walks it in the background, and builds an
-index in SQLite: EXIF, GPS, camera, dimensions, and hashes for spotting
-duplicates. Thumbnails are generated once as WebP in two sizes, 300px for the
+index in SQLite: EXIF, GPS, camera, dimensions, and hashes for duplicate
+detection. Thumbnails are generated once as WebP in two sizes, 300px for the
 grid and 1600px for the viewer, and cached on disk.
 
-On top of that index sit a date-grouped grid with a timeline scrubber, albums
-derived from the folder structure, a map for the 20% of photos carrying GPS, a
+On top of the index sit a date-grouped grid with a timeline scrubber, albums
+derived from the folder structure, a map for the 20% of photos with GPS, a
 full-screen viewer with pinch-to-zoom, and duplicate detection. Videos get an
-extracted frame for their thumbnail and transcoding for the formats browsers
-refuse to play. It installs as a PWA and caches thumbnails cache-first, so
-scrolling stays smooth on a phone over LAN.
+extracted frame for a thumbnail and transcoding for formats browsers will not
+play. It installs as a PWA and caches thumbnails cache-first.
 
 ## Finding people
 
-The part worth writing about is face recognition, because the first version of it
-did not work well enough to use.
-
 Faces are detected with SCRFD and embedded with ArcFace, both from InsightFace's
-`buffalo_l` pack. Each face becomes a 512-dimensional vector positioned so that
-the same person's faces land near each other. Clustering those vectors groups a
-person's photos with no labelling, and naming a cluster once names every photo in
-it.
+`buffalo_l` pack. Each face becomes a 512-dimensional vector where the same
+person's faces land close together. Clustering groups a person's photos without
+labelling, and naming a cluster names every photo in it.
 
-The first implementation used facenet-pytorch, which is from 2016-17 and trained
-on adult celebrities. A family library is mostly not that. It is profiles,
-ageing, bad light, film scans, and children, and facenet handled those badly
-enough that tuning the threshold only ever traded duplicate groups for merged
-blobs.
+The first implementation used facenet-pytorch, which dates from 2016-17 and was
+trained on adult celebrities. It handled profiles, ageing, poor light, film
+scans, and children badly enough that tuning the threshold traded duplicate
+groups for merged ones.
 
-To find out whether swapping models actually helped, I scored both on 2,000
-photos from the library, using pairs of faces appearing in the same photo as
-known negatives, since one person cannot be two faces in one frame:
+To measure whether changing models helped, I scored both on 2,000 photos from
+the library, using pairs of faces appearing in the same photo as known
+negatives:
 
 ```
                    faces/group   errors   false-merge rate
@@ -56,38 +50,35 @@ known negatives, since one person cannot be two faces in one frame:
 Four times fewer errors at the same consolidation, or 47% more consolidation at
 the same error rate.
 
-The number that explained why is the headroom between the two classes. Measuring
-the 1st percentile of definitely-different distances against the operating
-threshold: 0.353 against 0.30 for facenet, 0.649 against 0.45 for ArcFace.
-facenet left almost no gap between "same person" and "different person", so no
-threshold was ever going to be right.
+The headroom between the two classes explains the difference. Measuring the 1st
+percentile of definitely-different distances against the operating threshold:
+0.353 against 0.30 for facenet, 0.649 against 0.45 for ArcFace. facenet left
+little separation between same-person and different-person distances.
 
 Two things mattered as much as the model:
 
 - Alignment. ArcFace expects each face warped onto a canonical 112x112 using the
-  five landmarks from the detector. A plain crop gives up much of the benefit.
+  detector's five landmarks. A plain crop loses much of the gain.
 - Filtering. Unfiltered, the detector returns 64% more faces, but a third are
-  tiny or low-confidence people in the background, and those are where false
-  merges come from. Requiring 0.60 confidence and 40 pixels cut errors from 5 to
-  1 while keeping 68% of detections.
+  small or low-confidence background people, which is where false merges come
+  from. Requiring 0.60 confidence and 40 pixels cut errors from 5 to 1 while
+  keeping 68% of detections.
 
-## Searching by description
+## Search by description
 
-CLIP embeddings, via `open_clip`, let the library be searched in plain language
-rather than by filename or date. Both this and face recognition are optional; if
-the ML dependencies are not installed the app runs without those features instead
-of failing to start.
+CLIP embeddings, via `open_clip`, allow searching the library in plain language
+rather than by filename or date. Face recognition and semantic search are both
+optional; without the ML dependencies installed the app runs without them.
 
-## What the data turned out to be
+## Auditing the library first
 
-Auditing the library before building against it changed what got built. 26% of
-photos were dated exactly January 1, because their dates had been inferred from
-folder names and then presented as though they were exact. 1,399 files were
-redundant copies. 975 folders were being rendered as one flat, unnavigable grid.
-Each of those is a feature that only exists because the data was measured first.
+Measuring the library before building against it changed what got built. 26% of
+photos were dated exactly January 1, because dates had been inferred from folder
+names and stored as though they were exact. 1,399 files were redundant copies.
+975 folders were being rendered as a single flat grid.
 
 ## Stack
 
-Python 3.12 with FastAPI and SQLite via aiosqlite on the backend, Pillow for
-imaging, OpenCV for face processing. React 18, TypeScript, Vite, Tailwind, and
-SWR on the frontend. Runs under Docker or directly, on a machine on the LAN.
+Python 3.12 with FastAPI and SQLite via aiosqlite, Pillow for imaging, OpenCV
+for face processing. React 18, TypeScript, Vite, Tailwind, and SWR on the
+frontend. Runs under Docker or directly.


### PR DESCRIPTION
## The cache fix from #40 didn't work

Hosting matches `headers` rules against the **incoming request path**, before rewrites are applied. Every real page view — `/`, `/projects`, `/projects/nas-photo-browser` — is answered by the catch-all rewrite, and none of them is a literal request for `/index.html`. So the `/index.html` rule never fired, and the app shell kept being served with Firebase's default caching. That's why the NAS project still needed browser data cleared.

The `/content/**` rule did work, since those are direct file requests. Only the HTML shell was affected — but the shell is what loads everything else.

Now the broad rule is `**` → `no-cache`, with `/static/**` → `immutable` after it to take back the long max-age for content-hashed assets.

**One thing to verify after deploy.** This relies on a later matching rule overriding an earlier one for the same header key. I couldn't confirm the precedence against real Hosting from the build environment — its network policy blocks outbound hosts other than package registries. The ordering is chosen so that either outcome is still correct:

- If later wins (expected): `/static/**` stays `immutable`, everything else `no-cache`.
- If earlier wins: everything is `no-cache`, including static assets. Still correct, just one conditional request per asset — those filenames are content-hashed, so revalidation is a 304, not a re-download.

Worth a quick check once it's live:

```
curl -sI https://noahanderson.dev/ | grep -i cache-control                    # expect no-cache
curl -sI https://noahanderson.dev/projects | grep -i cache-control            # expect no-cache  ← the one that was broken
curl -sI https://noahanderson.dev/static/js/<hashed>.js | grep -i cache-control
```

If static comes back `no-cache`, swapping the two rule blocks fixes it.

## Frame Art

Second project entry. Same shape as the NAS one — private repo, runs on a LAN against your own hardware, so there's no code link or live URL and the detail page is the destination.

Written from the repository. The centerpiece is the split between Claude and local scoring, because it's the decision with the most engineering behind it: room analysis is one vision call per *room*, while the per-artwork match score is a local weighted sum (artist 0.25, style 0.20, color harmony 0.20, keyword 0.15, not-disliked 0.10, room 0.10). That's what keeps the browsing feed instant instead of one API request per card.

Also covers the color work — KMeans palette extraction, HSV harmony scoring on complementary/analogous relationships, and matte selection that deliberately separates in lightness from the wall so the matte doesn't disappear.

Note the README says three museums; the code has four (AIC, Met, Rijksmuseum, Smithsonian). I wrote from the code.

## Verification

Build clean. Rendered headless: `/projects`, both detail pages, a missing slug, and 390px mobile. No page errors, no horizontal overflow, benchmark and weights blocks render as `<pre>` rather than literal markdown, 404 state intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_014aLxQDSHyCGGU1t2RVD5Ux)_